### PR TITLE
Added srcset and higher resolution image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ $('.slb').simplebox({
 ```
 You can use `postfix` and `hqClass` options to customize the path to the image used in the pop-up. For every image defined as `<img src="[initial path].[extension]" class="slb [hqClass]" alt="[alt]">` simplebox will use `<img src="[initial path][postfix].[extension]" class="slb" alt="[alt]">`. Notice that you shouldn't use `hqClass` with images that don't have a version with the postfix.
 
+Simplebox will keep the values of `srcset` and `alt` attributes in the pop-up image.
+
 ## In the Wild
 
 - http://ratiksharma.com/blog/

--- a/README.md
+++ b/README.md
@@ -29,14 +29,17 @@ $(function () {
 
 ### Advanced
 
-The plugin comes with two options. Yes, just two. Think of this as a feature and not a drawback! If you want to access these options, call the plugin like this:
+The plugin comes with four options. Yes, just four. Think of this as a feature and not a drawback! If you want to access these options, call the plugin like this:
 
 ```JavaScript
 $('.slb').simplebox({
     fadeSpeed: 300, // default is 400ms, applied to all fade animations in the plugin
-    darkMode: true // default is false
+    darkMode: true, // default is false
+    postfix: "_full", // default is ""
+    hqClass: "highres" // default is "hq"
 });
 ```
+You can use `postfix` and `hqClass` options to customize the path to the image used in the pop-up. For every image defined as `<img src="[initial path].[extension]" class="slb [hqClass]" alt="[alt]">` simplebox will use `<img src="[initial path][postfix].[extension]" class="slb" alt="[alt]">`. Notice that you shouldn't use `hqClass` with images that don't have a version with the postfix.
 
 ## In the Wild
 

--- a/src/js/simplebox.js
+++ b/src/js/simplebox.js
@@ -5,7 +5,8 @@
         var settings = $.extend({
             fadeSpeed: 400,
             darkMode: false,
-            postfix: ""
+            postfix: "",
+            hqClass: "hq"
         }, options);
 
         // Helper Variables
@@ -58,7 +59,10 @@
 
                 var $this = $(this);
                 var imageSRC = $this.attr("src");
-                if (~$this.attr("class").indexOf("hq")) imageSRC = imageSRC.substring(0, imageSRC.lastIndexOf(".")) + settings.postfix + imageSRC.substring(imageSRC.lastIndexOf("."));
+                if (~$this.attr("class").indexOf(settings.hqClass)) {
+                    let dotIndex = imageSRC.lastIndexOf(".");
+                    imageSRC = imageSRC.substring(0, dotIndex) + settings.postfix + imageSRC.substring(dotIndex);
+                }
                 var imageSRCSET = $this.attr("srcset");
                 $image.attr("src", imageSRC);
                 $image.attr("srcset", imageSRCSET);

--- a/src/js/simplebox.js
+++ b/src/js/simplebox.js
@@ -64,8 +64,10 @@
                     imageSRC = imageSRC.substring(0, dotIndex) + settings.postfix + imageSRC.substring(dotIndex);
                 }
                 var imageSRCSET = $this.attr("srcset");
+                var imageALT = $this.attr("alt");
                 $image.attr("src", imageSRC);
                 $image.attr("srcset", imageSRCSET);
+                $image.attr("alt", imageALT);
                 $image.css("max-height", "80%");
                 $image.addClass('pop-in');
                 $image.removeClass('pop-out');

--- a/src/js/simplebox.js
+++ b/src/js/simplebox.js
@@ -4,7 +4,8 @@
     $.fn.simplebox = function(options) {
         var settings = $.extend({
             fadeSpeed: 400,
-            darkMode: false
+            darkMode: false,
+            postfix: ""
         }, options);
 
         // Helper Variables
@@ -57,7 +58,10 @@
 
                 var $this = $(this);
                 var imageSRC = $this.attr("src");
+                if (~$this.attr("class").indexOf("hq")) imageSRC = imageSRC.substring(0, imageSRC.lastIndexOf(".")) + settings.postfix + imageSRC.substring(imageSRC.lastIndexOf("."));
+                var imageSRCSET = $this.attr("srcset");
                 $image.attr("src", imageSRC);
+                $image.attr("srcset", imageSRCSET);
                 $image.css("max-height", "80%");
                 $image.addClass('pop-in');
                 $image.removeClass('pop-out');

--- a/src/js/simplebox.js
+++ b/src/js/simplebox.js
@@ -60,7 +60,7 @@
                 var $this = $(this);
                 var imageSRC = $this.attr("src");
                 if (~$this.attr("class").indexOf(settings.hqClass)) {
-                    let dotIndex = imageSRC.lastIndexOf(".");
+                    var dotIndex = imageSRC.lastIndexOf(".");
                     imageSRC = imageSRC.substring(0, dotIndex) + settings.postfix + imageSRC.substring(dotIndex);
                 }
                 var imageSRCSET = $this.attr("srcset");


### PR DESCRIPTION
1. Simplebox now transfers the value of the srcset attribute.
2. I also added the ability to define postfixes. For example, you have an image called `panda.jpg` and a high-res version `panda_full.jpg`. You can define `postfix: "_full"` and now simplebox will seek a version with the `_full` postfix for every image with an additional class `hq`.

PS I tested it in Chrome and it worked, but I didn't test it in other browsers yet. Also I didn't update `simplebox.min.js` yet, because I don't know which minifier do you use.